### PR TITLE
В ProfileLink компонент добавлена проверка на текущего пользователя

### DIFF
--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/SessionCard.razor.cs
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/SessionCard.razor.cs
@@ -36,7 +36,15 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Pages
       this.participantsChangedSubscription = await this.Service.SubscribeAsync<ParticipantsChangedNotification>(this.SessionId, notification => this.InvokeAsync(this.HandleNotification));
       this.voteSubscription = await this.Service.SubscribeAsync<VoteNotification>(this.SessionId, notification => this.InvokeAsync(() => this.HandleVoteNotification(notification)));
       this.participantChangedSubscription = await this.ScopedServices.GetRequiredService<ParticipantsService>()
-        .SubscribeAsync(notification => this.InvokeAsync(this.HandleNotification));
+        .SubscribeAsync(this.TryRefreshParticipantChanges);
+    }
+
+    private Task TryRefreshParticipantChanges(ParticipantChangedNotification arg)
+    {
+      // Если в списке участников есть тот, чья информация поменялась, то обновим.
+      return this.participantVotes.Any(p => p.Id == arg.ChangedInfo.Id) ?
+        this.InvokeAsync(this.HandleNotification) :
+        Task.CompletedTask;
     }
 
     private async Task RefreshAsync()

--- a/Yotalab.PlanningPoker.BlazorServerSide/Shared/ProfileLink.razor
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Shared/ProfileLink.razor
@@ -15,7 +15,14 @@
   {
     await base.OnInitializedAsync();
     this.participantInfo = await this.Service.GetInfoAsync(this.ParticipantId);
-    this.participantChangedSubscription = await this.Service.SubscribeAsync(notification => this.InvokeAsync(() => this.Refresh(notification.ChangedInfo)));
+    this.participantChangedSubscription = await this.Service.SubscribeAsync(this.TryRefreshIfCurrentParticipantChanged);
+  }
+
+  private Task TryRefreshIfCurrentParticipantChanged(ParticipantChangedNotification notification)
+  {
+    return notification.ChangedInfo.Id == this.ParticipantId ?
+      this.InvokeAsync(() => this.Refresh(notification.ChangedInfo)) :
+      Task.CompletedTask;
   }
 
   private void Refresh(ParticipantInfo info)


### PR DESCRIPTION
**Сделано**
В ProfileLink компонент добавлена проверка на текущего пользователя чтобы текущий пользователь не менялся.
Так же в SessionCard добавлена аналогичная проверка на то, что менялся один из участников сессии, иначе игнорируем.

**Проверено**
1. Участник 1 меняет свое имя
2. Участник 2 получает уведомление об изменении участника
3. Участник 2 меняет имя участника 1 в шапке приложения

Так же под отладкой проверял, что в карточке сессии при изменении совершенно другого участника, не входящую в сессию не вызывается обновление текущей сессии.