### PR TITLE
Добавлена возможность удалить сессию планирования

### DIFF
--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/JoinPrompt.razor
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/JoinPrompt.razor
@@ -1,20 +1,42 @@
-﻿@inject ParticipantsService Service
+﻿@using Yotalab.PlanningPoker.Grains.Interfaces.Models
+
+@inject NavigationManager NavigationManager
+@inject ParticipantsService Service
 
 <div class="alert alert-secondary mt-4" role="alert">
-  <strong class="me-2 align-middle">@Title</strong>
-  <button class="font-weight-bold btn btn-sm btn-primary"
-          @onclick="@(async () => await this.Service.JoinAsync(this.SessionId, this.ParticipantId))">
-    Присоединиться
-  </button>
+  <strong class="me-2 align-middle">@this.title</strong>
+  @if (this.sessionExists)
+  {
+    <button class="font-weight-bold btn btn-sm btn-success"
+            @onclick="@(async () => await this.Service.JoinAsync(this.Session.Id, this.ParticipantId))">
+      Присоединиться
+    </button>
+  }
+  else
+  {
+    <button class="font-weight-bold btn btn-sm btn-primary"
+            @onclick="@(() => this.NavigationManager.NavigateTo("/"))">
+      Вернуться к моим сессиям
+    </button>
+  }
 </div>
 
 @code {
-  [Parameter]
-  public string Title { get; set; }
+  private string title;
+  private bool sessionExists;
 
   [Parameter]
-  public Guid SessionId { get; set; }
+  public SessionInfo Session { get; set; }
 
   [Parameter]
   public Guid ParticipantId { get; set; }
+
+  protected override async Task OnParametersSetAsync()
+  {
+    await base.OnParametersSetAsync();
+    this.sessionExists = this.Session != null && this.Session.IsInitialized;
+    this.title = this.sessionExists ?
+      $"Вы не являетесь участником сессии '{this.Session.Name}'" :
+      "Сессии не существует";
+  }
 }

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/RemoveSessionModal.razor
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/RemoveSessionModal.razor
@@ -1,0 +1,25 @@
+﻿<div class="modal fade" id="@this.Id" tabindex="-1" aria-labelledby="removeSessionModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="removeSessionModalLabel"><span class="oi oi-warning text-danger me-2"></span> Удалить сессию</h5>
+        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        @if (this.Session != null)
+        {
+          <p>Сессию <b>"@this.Session.Name"</b> после удаления не восстановить.</p>
+        }
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+          Отменить
+        </button>
+        <button type="button" class="btn btn-danger" data-bs-dismiss="modal"
+                @onclick="@(async () => await this.ConfirmAsync())">
+          Удалить
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/RemoveSessionModal.razor.cs
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/RemoveSessionModal.razor.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Yotalab.PlanningPoker.Grains.Interfaces.Models;
+
+namespace Yotalab.PlanningPoker.BlazorServerSide.Pages.Components
+{
+  public partial class RemoveSessionModal : ComponentBase
+  {
+    [Parameter]
+    public string Id { get; set; }
+
+    [Parameter]
+    public SessionInfo Session { get; set; }
+
+    [Parameter]
+    public EventCallback<Guid> OnConfirm { get; set; }
+
+    private Task ConfirmAsync()
+    {
+      return this.OnConfirm.InvokeAsync(this.Session.Id);
+    }
+  }
+}

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/SessionCard.razor
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/SessionCard.razor
@@ -3,26 +3,24 @@
 @inherits AuthorizedOwningComponentBase<SessionService>
 @if (this.session != null)
 {
-  <div class="d-flex flex-row justify-content-center align-items-center mb-2">
-    <h1 class="text-center mb-0 mx-2">@this.session.Name</h1>
-    @if (this.session.ModeratorIds.Contains(this.ParticipantId))
-    {
-      <button class="btn h-100" data-bs-toggle="modal" data-bs-target="#sessionOptionsModal" @onclick="this.OnShowEditModal">
-        <span class="oi oi-pencil text-warning"></span>
-      </button>
-      <EditSessionModal Id="sessionOptionsModal" EditArgs="this.editSessionArgs" Title="Изменение сессии" OnConfirm="@this.HandleEditSessionConfirmAsync" />
-    }
-  </div>
-  <CascadingValue Value="@this.session">
-
-    @if (this.userNotJoinedToSession)
-    {
-      <JoinPrompt Title="@($"Вы не являетесь участником сессии '{this.session.Name}'")"
-                  SessionId="this.SessionId"
-                  ParticipantId="this.ParticipantId" />
-    }
-    else
-    {
+  @if (this.userNotJoinedToSession || !this.session.IsInitialized)
+  {
+    <JoinPrompt Session="this.session"
+                ParticipantId="this.ParticipantId" />
+  }
+  else
+  {
+    <div class="d-flex flex-row justify-content-center align-items-center mb-2">
+      <h1 class="text-center mb-0 mx-2">@this.session.Name</h1>
+      @if (this.session.ModeratorIds.Contains(this.ParticipantId))
+      {
+        <button class="btn h-100" data-bs-toggle="modal" data-bs-target="#sessionOptionsModal" @onclick="this.OnShowEditModal">
+          <span class="oi oi-pencil text-warning"></span>
+        </button>
+        <EditSessionModal Id="sessionOptionsModal" EditArgs="this.editSessionArgs" Title="Изменение сессии" OnConfirm="@this.HandleEditSessionConfirmAsync" />
+      }
+    </div>
+    <CascadingValue Value="@this.session">
       <div class="row g-3">
         <div class="col-md-5 col-lg-4 order-md-last mt-4">
           <SessionStatusPrompt ParticipantId="this.ParticipantId" />
@@ -52,8 +50,8 @@
           }
         </div>
       </div>
-    }
-  </CascadingValue>
+    </CascadingValue>
+  }
 }
 else
 {

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/SessionCard.razor.cs
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/SessionCard.razor.cs
@@ -75,9 +75,18 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Pages
     private async Task RefreshAsync()
     {
       this.session = await this.Service.GetAsync(this.SessionId);
-      this.participantVotes = await this.Service.ListParticipants(this.SessionId);
-      this.userNotJoinedToSession = !await this.Service.ParticipantJoined(this.SessionId, this.ParticipantId);
-      this.participantVote = this.participantVotes.SingleOrDefault(p => p.Id == this.ParticipantId)?.Vote;
+      if (session.IsInitialized)
+      {
+        this.participantVotes = await this.Service.ListParticipants(this.SessionId);
+        this.userNotJoinedToSession = !await this.Service.ParticipantJoined(this.SessionId, this.ParticipantId);
+        this.participantVote = this.participantVotes.SingleOrDefault(p => p.Id == this.ParticipantId)?.Vote;
+      }
+      else
+      {
+        this.participantVotes = new List<ParticipantInfoDTO>();
+        this.userNotJoinedToSession = true;
+        this.participantVote = Vote.Unset;
+      }
     }
 
     private async Task HandleNotification()

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/SessionCard.razor.cs
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/SessionCard.razor.cs
@@ -26,21 +26,42 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Pages
     private StreamSubscriptionHandle<VoteNotification> voteSubscription;
     private StreamSubscriptionHandle<ParticipantChangedNotification> participantChangedSubscription;
     private StreamSubscriptionHandle<SessionInfoChangedNotification> sessionInfoChangedSubscription;
+    private StreamSubscriptionHandle<SessionRemovedNotification> sessionRemovedSubscription;
 
     [Parameter]
     public Guid SessionId { get; set; }
+
+    [Inject]
+    private NavigationManager NavigationManager { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
       await base.OnInitializedAsync();
       await this.RefreshAsync();
 
-      this.sessionProcessingSubscription = await this.Service.SubscribeAsync<SessionProcessingNotification>(this.SessionId, notification => this.InvokeAsync(this.HandleNotification));
-      this.participantsChangedSubscription = await this.Service.SubscribeAsync<ParticipantsChangedNotification>(this.SessionId, notification => this.InvokeAsync(this.HandleNotification));
-      this.voteSubscription = await this.Service.SubscribeAsync<VoteNotification>(this.SessionId, notification => this.InvokeAsync(() => this.HandleVoteNotification(notification)));
+      // Обработка изменения состояния сессии (начало голосования, остановка, и т.п.).
+      this.sessionProcessingSubscription = await this.Service.SubscribeAsync<SessionProcessingNotification>(this.SessionId,
+        notification => this.InvokeAsync(this.HandleNotification));
+
+      // Обработка изменения участников (кого-то добавили, кого-то удалили и т.п.).
+      this.participantsChangedSubscription = await this.Service.SubscribeAsync<ParticipantsChangedNotification>(this.SessionId,
+        notification => this.InvokeAsync(this.HandleNotification));
+
+      // Обработка появления нового голоса.
+      this.voteSubscription = await this.Service.SubscribeAsync<VoteNotification>(this.SessionId,
+        notification => this.InvokeAsync(() => this.HandleVoteNotification(notification)));
+
+      // Обработка изменения одного из участников.
       this.participantChangedSubscription = await this.ScopedServices.GetRequiredService<ParticipantsService>()
         .SubscribeAsync(this.TryRefreshParticipantChanges);
-      this.sessionInfoChangedSubscription = await this.Service.SubscribeAsync<SessionInfoChangedNotification>(this.SessionId, _ => this.InvokeAsync(this.HandleNotification));
+
+      // Обработка изменения информации о сессии.
+      this.sessionInfoChangedSubscription = await this.Service.SubscribeAsync<SessionInfoChangedNotification>(this.SessionId,
+        _ => this.InvokeAsync(this.HandleNotification));
+
+      // Обработка удаления сессии.
+      this.sessionRemovedSubscription = await this.Service.SubscribeAsync<SessionRemovedNotification>(this.SessionId,
+        _ => this.InvokeAsync(() => this.NavigationManager.NavigateTo("/")));
     }
 
     private Task TryRefreshParticipantChanges(ParticipantChangedNotification arg)
@@ -62,6 +83,8 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Pages
     private async Task HandleNotification()
     {
       await this.RefreshAsync();
+      if (this.userNotJoinedToSession)
+        this.NavigationManager.NavigateTo("/");
       this.StateHasChanged();
     }
 
@@ -107,6 +130,7 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Pages
         await this.voteSubscription?.UnsubscribeAsync();
         await this.participantChangedSubscription?.UnsubscribeAsync();
         await this.sessionInfoChangedSubscription?.UnsubscribeAsync();
+        await this.sessionRemovedSubscription?.UnsubscribeAsync();
       }
       catch
       {

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Sessions.razor
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Sessions.razor
@@ -1,6 +1,7 @@
 ﻿@page "/"
 
 @inherits AuthorizedOwningComponentBase<SessionService>
+@inject NavigationManager NavigationManager
 
 <h1 class="text-center">Мои сессии</h1>
 
@@ -13,9 +14,10 @@
         {
           foreach (var session in this.sessions)
           {
-            <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
-               href="sessions/@(session.Id)">
-              <div>
+            <div class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+              <div class="flex-fill"
+                   style="cursor:pointer"
+                   @onclick="@(() => NavigationManager.NavigateTo($"sessions/{session.Id}"))">
                 @session.Name
                 @if (session.ProcessingState == Grains.Interfaces.Models.SessionProcessingState.Started)
                 {
@@ -29,7 +31,24 @@
                 }
                 <span class="badge bg-success">участников: @session.ParticipantsCount</span>
               </div>
-            </a>
+              <div class="ms-2">
+                @{ 
+                  var sessionContextMenuItems = new List<DropDownMenuItem>();
+                  sessionContextMenuItems.Add(new DropDownMenuItem()
+                  {
+                    ItemTemplate = @<button class="dropdown-item"><span class="oi oi-x text-danger me-2"></span>Удалить</button>
+                  });
+                }
+
+                <DropDownMenu Items="sessionContextMenuItems">
+                  <ButtonTemplate>
+                    <button class="btn btn-sm p-0 m-0 ps-1 pe-1">
+                      <span class="oi oi-ellipses"></span>
+                    </button>
+                  </ButtonTemplate>
+                </DropDownMenu>
+              </div>
+            </div>
           }
         }
         else

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Sessions.razor
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Sessions.razor
@@ -38,8 +38,10 @@
                   sessionContextMenuItems.Add(new DropDownMenuItem()
                   {
                     ItemTemplate =
-                @<button class="dropdown-item" @onclick="@(() => this.RemoveSessionAsync(session.Id))">
-                  <span class="oi oi-x text-danger me-2"></span>Удалить
+                @<button class="dropdown-item"
+                         data-bs-toggle="modal" data-bs-target="#removeSessionModal"
+                         @onclick="@(() => this.ShowRemoveSessionConfirmation(session.Id))">
+                  <span class="oi oi-trash text-danger me-2"></span>Удалить
                 </button>
                   });
 
@@ -69,6 +71,7 @@
     </div>
   </div>
 
+  <RemoveSessionModal Id="removeSessionModal" Session="@this.sessionToDelete" OnConfirm="@this.RemoveSessionAsync" />
   <EditSessionModal Id="newSessionModal" Title="Новая сессия" EditArgs="this.newSessionArgs" OnConfirm="@this.CreateSessionAsync" />
 }
 else

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Sessions.razor
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Sessions.razor
@@ -32,11 +32,14 @@
                 <span class="badge bg-success">участников: @session.ParticipantsCount</span>
               </div>
               <div class="ms-2">
-                @{ 
+                @{
                   var sessionContextMenuItems = new List<DropDownMenuItem>();
                   sessionContextMenuItems.Add(new DropDownMenuItem()
                   {
-                    ItemTemplate = @<button class="dropdown-item"><span class="oi oi-x text-danger me-2"></span>Удалить</button>
+                    ItemTemplate =
+                  @<button class="dropdown-item" @onclick="@(() => this.RemoveSessionAsync(session.Id))">
+                    <span class="oi oi-x text-danger me-2"></span>Удалить
+                  </button>
                   });
                 }
 

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Sessions.razor
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Sessions.razor
@@ -32,24 +32,25 @@
                 <span class="badge bg-success">участников: @session.ParticipantsCount</span>
               </div>
               <div class="ms-2">
-                @{
+                @if (session.ModeratorIds.Contains(this.ParticipantId))
+                {
                   var sessionContextMenuItems = new List<DropDownMenuItem>();
                   sessionContextMenuItems.Add(new DropDownMenuItem()
                   {
                     ItemTemplate =
-                  @<button class="dropdown-item" @onclick="@(() => this.RemoveSessionAsync(session.Id))">
-                    <span class="oi oi-x text-danger me-2"></span>Удалить
-                  </button>
+                @<button class="dropdown-item" @onclick="@(() => this.RemoveSessionAsync(session.Id))">
+                  <span class="oi oi-x text-danger me-2"></span>Удалить
+                </button>
                   });
-                }
 
-                <DropDownMenu Items="sessionContextMenuItems">
-                  <ButtonTemplate>
-                    <button class="btn btn-sm p-0 m-0 ps-1 pe-1">
-                      <span class="oi oi-ellipses"></span>
-                    </button>
-                  </ButtonTemplate>
-                </DropDownMenu>
+                  <DropDownMenu Items="sessionContextMenuItems">
+                    <ButtonTemplate>
+                      <button class="btn btn-sm p-0 m-0 ps-1 pe-1">
+                        <span class="oi oi-ellipses"></span>
+                      </button>
+                    </ButtonTemplate>
+                  </DropDownMenu>
+                }
               </div>
             </div>
           }

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Sessions.razor.cs
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Sessions.razor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Yotalab.PlanningPoker.BlazorServerSide.Pages.Components;
 using Yotalab.PlanningPoker.BlazorServerSide.Services;
@@ -27,6 +28,13 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Pages
     {
       var result = await this.Service.CreateAsync(args.Name, this.participantId);
       this.sessions.Add(result);
+    }
+
+    private async Task RemoveSessionAsync(Guid sessionId)
+    {
+      var session = this.sessions.Single(s => s.Id == sessionId);
+      await this.Service.Remove(sessionId, this.participantId);
+      this.sessions.Remove(session);
     }
 
     private void OnShowCreationModal()

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Sessions.razor.cs
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Sessions.razor.cs
@@ -14,6 +14,7 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Pages
     private Guid participantId;
     private List<SessionInfo> sessions;
     private EditSessionArgs newSessionArgs;
+    private SessionInfo sessionToDelete;
 
     protected override async Task OnInitializedAsync()
     {
@@ -32,9 +33,21 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Pages
 
     private async Task RemoveSessionAsync(Guid sessionId)
     {
-      var session = this.sessions.Single(s => s.Id == sessionId);
-      await this.Service.Remove(sessionId, this.participantId);
-      this.sessions.Remove(session);
+      try
+      {
+        var session = this.sessions.Single(s => s.Id == sessionId);
+        await this.Service.Remove(sessionId, this.participantId);
+        this.sessions.Remove(session);
+      }
+      finally
+      {
+        this.sessionToDelete = null;
+      }
+    }
+
+    private void ShowRemoveSessionConfirmation(Guid sessionId)
+    {
+      this.sessionToDelete = this.sessions.Single(s => s.Id == sessionId);
     }
 
     private void OnShowCreationModal()

--- a/Yotalab.PlanningPoker.BlazorServerSide/Services/SessionService.cs
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Services/SessionService.cs
@@ -73,25 +73,25 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Services
       return result;
     }
 
-    internal Task StopAsync(Guid sessionId, Guid participantId)
+    public Task StopAsync(Guid sessionId, Guid participantId)
     {
       var sessionGrain = this.client.GetGrain<ISessionGrain>(sessionId);
       return sessionGrain.StopAsync(participantId);
     }
 
-    internal Task FinishAsync(Guid sessionId, Guid participantId)
+    public Task FinishAsync(Guid sessionId, Guid participantId)
     {
       var sessionGrain = this.client.GetGrain<ISessionGrain>(sessionId);
       return sessionGrain.FinishAsync(participantId);
     }
 
-    internal Task StartAsync(Guid sessionId, Guid participantId)
+    public Task StartAsync(Guid sessionId, Guid participantId)
     {
       var sessionGrain = this.client.GetGrain<ISessionGrain>(sessionId);
       return sessionGrain.StartAsync(participantId);
     }
 
-    internal Task ResetAsync(Guid sessionId, Guid participantId)
+    public Task ResetAsync(Guid sessionId, Guid participantId)
     {
       var sessionGrain = this.client.GetGrain<ISessionGrain>(sessionId);
       return sessionGrain.ResetAsync(participantId);
@@ -131,6 +131,12 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Services
     {
       var sessionGrain = this.client.GetGrain<ISessionGrain>(sessionId);
       return sessionGrain.RemoveModerator(participantId);
+    }
+
+    public Task Remove(Guid sessionId, Guid participantId)
+    {
+      var sessionGrain = this.client.GetGrain<ISessionGrain>(sessionId);
+      return sessionGrain.Remove(participantId);
     }
 
     public Task<StreamSubscriptionHandle<T>> SubscribeAsync<T>(Guid sessionId, Func<T, Task> action) =>

--- a/Yotalab.PlanningPoker.Grains.Interfaces/ISessionGrain.cs
+++ b/Yotalab.PlanningPoker.Grains.Interfaces/ISessionGrain.cs
@@ -110,5 +110,12 @@ namespace Yotalab.PlanningPoker.Grains.Interfaces
     /// <param name="args">Аргументы изменения информации о сессии.</param>
     /// <returns>Задача на изменение настроек сессии.</returns>
     Task ChangeInfo(ChangeSessionInfoArgs args);
+
+    /// <summary>
+    /// Удалить сессию.
+    /// </summary>
+    /// <param name="initiatorId">Инициатор участника, удаляющего сессию.</param>
+    /// <returns>Задача на удаление сессии.</returns>
+    Task Remove(Guid initiatorId);
   }
 }

--- a/Yotalab.PlanningPoker.Grains.Interfaces/Models/Notifications/SessionRemovedNotification.cs
+++ b/Yotalab.PlanningPoker.Grains.Interfaces/Models/Notifications/SessionRemovedNotification.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Orleans.Concurrency;
+
+namespace Yotalab.PlanningPoker.Grains.Interfaces.Models.Notifications
+{
+  [Immutable]
+  public class SessionRemovedNotification
+  {
+    public SessionRemovedNotification(Guid sessionId)
+    {
+      this.SessionId = sessionId;
+    }
+
+    /// <summary>
+    /// Получить идентификатор сессии.
+    /// </summary>
+    public Guid SessionId { get; }
+  }
+}

--- a/Yotalab.PlanningPoker.Grains.Interfaces/Models/SessionInfo.cs
+++ b/Yotalab.PlanningPoker.Grains.Interfaces/Models/SessionInfo.cs
@@ -21,6 +21,11 @@ namespace Yotalab.PlanningPoker.Grains.Interfaces.Models
     public string Name { get; set; }
 
     /// <summary>
+    /// Получить или установить признак того, что сессия инициализирована.
+    /// </summary>
+    public bool IsInitialized { get; set; }
+
+    /// <summary>
     /// Получить или установить состояние сессии.
     /// </summary>
     public SessionProcessingState ProcessingState { get; set; }

--- a/Yotalab.PlanningPoker.Grains/SessionGrain.cs
+++ b/Yotalab.PlanningPoker.Grains/SessionGrain.cs
@@ -335,14 +335,28 @@ namespace Yotalab.PlanningPoker.Grains
 
     private SessionInfo ToInfo()
     {
+      if (this.grainState.RecordExists)
+      {
+        var hasModerators = this.grainState.State.ModeratorIds.Any();
+        var hasParticipants = this.grainState.State.ParticipantVotes.Any();
+        return new SessionInfo()
+        {
+          Id = this.GetPrimaryKey(),
+          // Косвенно определяем, что сессии существует по наличию в ней модераторов.
+          // Ситуации, когда в сессии нет модераторов быть не может для живой сессии,
+          //   иначе считаем такую сессию не инициализированной.
+          IsInitialized = hasModerators,
+          ModeratorId = this.grainState.State.ModeratorId,
+          ModeratorIds = hasModerators ? this.grainState.State.ModeratorIds.ToImmutableArray() : ImmutableArray<Guid>.Empty,
+          Name = this.grainState.State.Name,
+          ProcessingState = this.grainState.State.ProcessingState,
+          ParticipantsCount = hasParticipants ? this.grainState.State.ParticipantVotes.Keys.Count : 0
+        };
+      }
+
       return new SessionInfo()
       {
-        Id = this.GetPrimaryKey(),
-        ModeratorId = this.grainState.State.ModeratorId,
-        ModeratorIds = this.grainState.State.ModeratorIds.ToImmutableArray(),
-        Name = this.grainState.State.Name,
-        ProcessingState = this.grainState.State.ProcessingState,
-        ParticipantsCount = this.grainState.State.ParticipantVotes.Keys.Count
+        IsInitialized = false
       };
     }
 


### PR DESCRIPTION
**Сделано**
- Добавлен метод в ISessionGrain
- Добавлен признак IsInitialized, по которому определяется существует ли сессии. Так же при переходе по ссылке не отображается кнопка присоединиться, если IsInitialized = false
- Добавлено контекстное меню для сессии в списке и диалог подтверждения удаления
- Удалять может только модератор, и при удалении пользователей находящихся в карточке выкидывает на список сессий

**Не сделано**
Идеально было бы не просто выкидывать на список сессий, но перед этим модалку показать, о том что сессия удалена. Не стал делать, в целом можно сделать отдельно в будущем, как UX улучшение, на фичу не влияет.

**Критерии**
 - [x] Нужно подтверждение или возможность отмены операции.
 - [x] Все Grains должны быть удалены из хранилища.
 - [x] Для пользователей находящихся в сессии должно быть уведомление о том, что сессия удалена модератором и после должно перекинуть на список сессий.
 - [x] При переходе по ссылке на удаленную сессию не должно быть кнопки "Присоединиться"