### PR TITLE
Добавлено свойство для состояния сессии - бюллетень голосования, которое позволяет настроить доступный набор карт

### DIFF
--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/EditSessionModal.razor
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/EditSessionModal.razor
@@ -15,6 +15,20 @@
               <InputTextOnInput @bind-Value="@this.EditArgs.Name" class="form-control" />
               <ValidationMessage For="@(() => this.EditArgs.Name)" />
             </div>
+            <div class="d-flex flex-wrap justify-content-center">
+              @foreach (var bulletinItem in this.EditArgs.Bulletin)
+              {
+                var vote = bulletinItem.Vote;
+                if (vote.IsUnset)
+                  continue;
+
+                var voteChecked = !bulletinItem.IsDisabled;
+                <div class="shadow-sm me-4 mb-4 d-flex p-1 rounded" style="min-width:90px;cursor:pointer">
+                  <input id="@vote.Value" type="checkbox" @onchange="@((args) => this.HandleCheckVote(vote))" checked="@voteChecked" style="cursor:inherit" />
+                  <label class="flex-fill h1 text-center" for="@vote.Value" style="cursor:inherit">@vote.Value</label>
+                </div>
+              }
+            </div>
           </div>
           <div class="modal-footer">
             <button type="submit"

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/EditSessionModal.razor.cs
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/EditSessionModal.razor.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Yotalab.PlanningPoker.BlazorServerSide.Services.Args;
 using Yotalab.PlanningPoker.BlazorServerSide.Shared;
+using Yotalab.PlanningPoker.Grains.Interfaces.Models;
 
 namespace Yotalab.PlanningPoker.BlazorServerSide.Pages.Components
 {
@@ -53,6 +54,14 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Pages.Components
     {
       this.formInvalid = !this.editContext.Validate();
       StateHasChanged();
+    }
+
+    private void HandleCheckVote(Vote vote)
+    {
+      if (this.EditArgs.Bulletin.IsEnabled(vote))
+        this.EditArgs.Bulletin.Disable(vote);
+      else
+        this.EditArgs.Bulletin.Enable(vote);
     }
 
     private Task ConfirmAsync()

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/ParticipantsVotesResult.razor
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/ParticipantsVotesResult.razor
@@ -1,6 +1,6 @@
 ﻿@using Yotalab.PlanningPoker.BlazorServerSide.Services.DTO
 
-<RadzenChart>
+<RadzenChart @ref="chart">
   <RadzenDonutSeries Data="@this.chartData" CategoryProperty="Vote" ValueProperty="ParticipantCount" Radius="150" InnerRadius="140">
     <TitleTemplate>
       <div class="rz-donut-content">
@@ -12,6 +12,7 @@
 </RadzenChart>
 
 @code {
+  private RadzenChart chart;
   private List<DataItem> chartData = new List<DataItem>();
 
   private double average;
@@ -38,6 +39,8 @@
         ParticipantCount = voteCount
       });
     }
+
+    this.chart?.Reload();
   }
 
   private string FormatPercents(double percents)

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/PokerCardDeck.razor
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/PokerCardDeck.razor
@@ -1,18 +1,21 @@
-﻿@using Yotalab.PlanningPoker.Grains.Interfaces.Models
-@inherits OwningComponentBase<ParticipantsService>
+﻿@inherits OwningComponentBase<ParticipantsService>
 
-<div class="row justify-content-md-center">
-  @foreach (var vote in Vote.GetAll())
-  {
-    if (Vote.Unset.Equals(vote))
-      continue;
+@if (this.Bulletin != null)
+{
+  <div class="row justify-content-md-center">
+    @foreach (var bulletinItem in this.Bulletin)
+    {
+      var vote = bulletinItem.Vote;
+      if (vote.IsUnset || bulletinItem.IsDisabled)
+        continue;
 
-    <div class="col-auto">
-      <PokerCard @key="vote.Value"
-                 SessionId="this.SessionId"
-                 Value="vote"
-                 Selected="@(this.selectedVote?.Equals(vote) == true)"
-                 OnSelectedChanged="this.HandleSelectedChanged" />
-    </div>
-  }
-</div>
+      <div class="col-auto">
+        <PokerCard @key="vote.Value"
+                   SessionId="this.SessionId"
+                   Value="vote"
+                   Selected="@(this.selectedVote?.Equals(vote) == true)"
+                   OnSelectedChanged="this.HandleSelectedChanged" />
+      </div>
+    }
+  </div>
+}

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/PokerCardDeck.razor.cs
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/PokerCardDeck.razor.cs
@@ -24,6 +24,9 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Pages.Components
     public Vote ParticipantVote { get; set; }
 
     [Parameter]
+    public Bulletin Bulletin { get; set; }
+
+    [Parameter]
     public bool CanVote { get; set; }
 
     protected override void OnParametersSet()

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/SessionCard.razor
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/SessionCard.razor
@@ -39,6 +39,7 @@
             if (this.User != null)
             {
               <PokerCardDeck SessionId="this.SessionId"
+                             Bulletin="this.bulletin"
                              ParticipantId="this.ParticipantId"
                              ParticipantVote="this.participantVote"
                              CanVote="this.session.ProcessingState == SessionProcessingState.Started || this.session.ProcessingState == SessionProcessingState.Stopped" />

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/SessionCard.razor.cs
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/SessionCard.razor.cs
@@ -19,6 +19,7 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Pages
     private EditSessionArgs editSessionArgs;
     private Vote participantVote;
     private SessionInfo session;
+    private Bulletin bulletin;
     private IReadOnlyCollection<ParticipantInfoDTO> participantVotes;
     private bool userNotJoinedToSession = false;
     private StreamSubscriptionHandle<SessionProcessingNotification> sessionProcessingSubscription;
@@ -80,6 +81,7 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Pages
         this.participantVotes = await this.Service.ListParticipants(this.SessionId);
         this.userNotJoinedToSession = !await this.Service.ParticipantJoined(this.SessionId, this.ParticipantId);
         this.participantVote = this.participantVotes.SingleOrDefault(p => p.Id == this.ParticipantId)?.Vote;
+        this.bulletin = await this.Service.GetBulletin(this.SessionId);
       }
       else
       {
@@ -126,7 +128,8 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Pages
       this.editSessionArgs = new EditSessionArgs()
       {
         Name = this.session?.Name,
-        SessionId = this.SessionId
+        SessionId = this.SessionId,
+        Bulletin = new Bulletin(this.bulletin)
       };
     }
 

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Sessions.razor.cs
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Sessions.razor.cs
@@ -27,7 +27,7 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Pages
 
     private async Task CreateSessionAsync(EditSessionArgs args)
     {
-      var result = await this.Service.CreateAsync(args.Name, this.participantId);
+      var result = await this.Service.CreateAsync(args.Name, this.participantId, args.Bulletin);
       this.sessions.Add(result);
     }
 
@@ -54,7 +54,8 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Pages
     {
       this.newSessionArgs = new EditSessionArgs()
       {
-        Name = "Новая сессия"
+        Name = "Новая сессия",
+        Bulletin = Bulletin.Default()
       };
     }
   }

--- a/Yotalab.PlanningPoker.BlazorServerSide/Services/Args/EditSessionArgs.cs
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Services/Args/EditSessionArgs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using Yotalab.PlanningPoker.Grains.Interfaces.Models;
 
 namespace Yotalab.PlanningPoker.BlazorServerSide.Services.Args
 {
@@ -18,5 +19,10 @@ namespace Yotalab.PlanningPoker.BlazorServerSide.Services.Args
     /// </summary>
     [Required(ErrorMessage = "Имя сессии не может быть пустым!")]
     public string Name { get; set; }
+
+    /// <summary>
+    /// Получить или установить бюллетень голосования.
+    /// </summary>
+    public Bulletin Bulletin { get; set; }
   }
 }

--- a/Yotalab.PlanningPoker.Grains.Interfaces/ISessionGrain.cs
+++ b/Yotalab.PlanningPoker.Grains.Interfaces/ISessionGrain.cs
@@ -17,8 +17,9 @@ namespace Yotalab.PlanningPoker.Grains.Interfaces
     /// </summary>
     /// <param name="name">Имя сессии.</param>
     /// <param name="moderator">Модератор сессии.</param>
+    /// <param name="bulletin">Бюллетень голосования.</param>
     /// <returns>Задача на создание сессии.</returns>
-    Task CreateAsync(string name, IParticipantGrain moderator);
+    Task CreateAsync(string name, IParticipantGrain moderator, Bulletin bulletin);
 
     /// <summary>
     /// Получить статус сессии.
@@ -125,5 +126,18 @@ namespace Yotalab.PlanningPoker.Grains.Interfaces
     /// <param name="initiatorId">Инициатор участника, удаляющего сессию.</param>
     /// <returns>Задача на удаление сессии.</returns>
     Task Remove(Guid initiatorId);
+
+    /// <summary>
+    /// Получить бюллетень для голосования.
+    /// </summary>
+    /// <returns>Задача на получение бюллетени.</returns>
+    Task<Bulletin> GetBulletin();
+
+    /// <summary>
+    /// Изменить бюллетень.
+    /// </summary>
+    /// <param name="newBulletin">Новая бюллетень.</param>
+    /// <returns>Задача на изменение бюллетени.</returns>
+    Task ChangeBulletin(Bulletin newBulletin);
   }
 }

--- a/Yotalab.PlanningPoker.Grains.Interfaces/Models/Bulletin.cs
+++ b/Yotalab.PlanningPoker.Grains.Interfaces/Models/Bulletin.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Orleans.Concurrency;
+
+namespace Yotalab.PlanningPoker.Grains.Interfaces.Models
+{
+  /// <summary>
+  /// Бюллетень голосования, с возможными для выбора голосами.
+  /// </summary>
+  [Immutable]
+  public class Bulletin : HashSet<BulletinItem>
+  {
+    /// <summary>
+    /// Бюллетень по-умолчанию из последовательности Фиббоначи, знака вопроса и чашки кофе.
+    /// </summary>
+    /// <returns>Бюлетень по-умолчанию.</returns>
+    public static Bulletin Default()
+    {
+      return new Bulletin(Vote.GetAll());
+    }
+
+    /// <summary>
+    /// Отметить голос, как недоступный для выбора.
+    /// </summary>
+    /// <param name="vote">Голос.</param>
+    public void Disable(Vote vote)
+    {
+      foreach (var item in this)
+      {
+        if (Equals(item.Vote, vote))
+          item.Disable();
+      }
+    }
+
+    /// <summary>
+    /// Отметить голос, как доступный для выбора.
+    /// </summary>
+    /// <param name="vote">Голос.</param>
+    public void Enable(Vote vote)
+    {
+      foreach (var item in this)
+      {
+        if (Equals(item.Vote, vote))
+          item.Enable();
+      }
+    }
+
+    /// <summary>
+    /// Проверить, доступен ли голос для выбора.
+    /// </summary>
+    /// <param name="vote">Голос.</param>
+    /// <returns>True, если голос доступен для выбора, иначе - false.</returns>
+    public bool IsEnabled(Vote vote)
+    {
+      return this.Any(item => Equals(item.Vote, vote) && !item.IsDisabled);
+    }
+
+    public Bulletin(IEnumerable<Vote> votes)
+      : base(votes.Select(v => new BulletinItem(v)), new BulletinItemComparer())
+    {
+    }
+
+    public Bulletin(Bulletin bulletin)
+      : base(bulletin, new BulletinItemComparer())
+    {
+    }
+
+    private Bulletin()
+    {
+      // Требует десериализатор.
+    }
+  }
+}

--- a/Yotalab.PlanningPoker.Grains.Interfaces/Models/BulletinItem.cs
+++ b/Yotalab.PlanningPoker.Grains.Interfaces/Models/BulletinItem.cs
@@ -1,0 +1,50 @@
+﻿namespace Yotalab.PlanningPoker.Grains.Interfaces.Models
+{
+  /// <summary>
+  /// Элемент бюллетени.
+  /// </summary>
+  public class BulletinItem
+  {
+    /// <summary>
+    /// Получить голос связанный с элементом бюллетени.
+    /// </summary>
+    public Vote Vote { get; private set; }
+
+    /// <summary>
+    /// Получить признак того, что элемент бюллетени недоступен.
+    /// </summary>
+    public bool IsDisabled { get; private set; }
+
+    /// <summary>
+    /// Сделать элемент бюллетени недоступным.
+    /// </summary>
+    internal void Disable()
+    {
+      this.IsDisabled = true;
+    }
+
+    /// <summary>
+    /// Сделать элемент бюллетени доступным.
+    /// </summary>
+    internal void Enable()
+    {
+      this.IsDisabled = false;
+    }
+
+    public BulletinItem(Vote vote)
+      : this(vote, false)
+    {
+    }
+
+    public BulletinItem(Vote vote, bool disabled)
+    {
+      this.Vote = vote;
+      this.IsDisabled = disabled;
+    }
+
+    private BulletinItem()
+    {
+      // Требует десериализатор.
+    }
+  }
+}

--- a/Yotalab.PlanningPoker.Grains.Interfaces/Models/BulletinItemComparer.cs
+++ b/Yotalab.PlanningPoker.Grains.Interfaces/Models/BulletinItemComparer.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+
+namespace Yotalab.PlanningPoker.Grains.Interfaces.Models
+{
+  /// <summary>
+  /// Сравниватель элементов бюллетени.
+  /// Сравнивает по голосу, игнорируя признак недоступности.
+  /// </summary>
+  internal class BulletinItemComparer : IEqualityComparer<BulletinItem>
+  {
+    #region IEqualityComparer<BulletinItem>
+
+    public bool Equals(BulletinItem x, BulletinItem y)
+    {
+      if (x == null && y == null)
+        return true;
+      else if (x == null || y == null)
+        return false;
+
+      return x.Vote.Equals(y.Vote);
+    }
+
+    public int GetHashCode(BulletinItem obj)
+    {
+      return obj.Vote.GetHashCode();
+    }
+
+    #endregion
+  }
+}

--- a/Yotalab.PlanningPoker.Grains.Interfaces/Models/Vote.cs
+++ b/Yotalab.PlanningPoker.Grains.Interfaces/Models/Vote.cs
@@ -33,9 +33,35 @@ namespace Yotalab.PlanningPoker.Grains.Interfaces.Models
     public string Value { get; private set; }
 
     /// <summary>
+    /// Получить признак того, что голос отключен.
+    /// </summary>
+    public bool IsDisabled { get; private set; }
+
+    /// <summary>
     /// Получить признак того, что голос является числовой оценкой.
     /// </summary>
     public bool IsNumber => double.TryParse(this.Value, out _);
+
+    /// <summary>
+    /// Получить признак того, что голос не установлен.
+    /// </summary>
+    public bool IsUnset => Vote.Unset.Equals(this);
+
+    public Vote AsDisabled()
+    {
+      return new Vote(this.Value)
+      {
+        IsDisabled = true
+      };
+    }
+
+    public Vote AsEnabled()
+    {
+      return new Vote(this.Value)
+      {
+        IsDisabled = false
+      };
+    }
 
     /// <summary>
     /// Получить все возможные значения голосов.

--- a/Yotalab.PlanningPoker.Grains.Interfaces/Models/Vote.cs
+++ b/Yotalab.PlanningPoker.Grains.Interfaces/Models/Vote.cs
@@ -33,11 +33,6 @@ namespace Yotalab.PlanningPoker.Grains.Interfaces.Models
     public string Value { get; private set; }
 
     /// <summary>
-    /// Получить признак того, что голос отключен.
-    /// </summary>
-    public bool IsDisabled { get; private set; }
-
-    /// <summary>
     /// Получить признак того, что голос является числовой оценкой.
     /// </summary>
     public bool IsNumber => double.TryParse(this.Value, out _);
@@ -46,22 +41,6 @@ namespace Yotalab.PlanningPoker.Grains.Interfaces.Models
     /// Получить признак того, что голос не установлен.
     /// </summary>
     public bool IsUnset => Vote.Unset.Equals(this);
-
-    public Vote AsDisabled()
-    {
-      return new Vote(this.Value)
-      {
-        IsDisabled = true
-      };
-    }
-
-    public Vote AsEnabled()
-    {
-      return new Vote(this.Value)
-      {
-        IsDisabled = false
-      };
-    }
 
     /// <summary>
     /// Получить все возможные значения голосов.

--- a/Yotalab.PlanningPoker.Grains/SessionGrain.cs
+++ b/Yotalab.PlanningPoker.Grains/SessionGrain.cs
@@ -258,7 +258,10 @@ namespace Yotalab.PlanningPoker.Grains
       {
         var vote = this.grainState.State.ParticipantVotes[voteKey];
         if (!bulletine.IsEnabled(vote))
-          this.grainState.State.ParticipantVotes[voteKey] = Vote.Unset;
+        {
+          var isSessionFinished = this.grainState.State.ProcessingState == SessionProcessingState.Finished;
+          this.grainState.State.ParticipantVotes[voteKey] = isSessionFinished ? Vote.IDontKnown : Vote.Unset;
+        }
       }
 
       this.NotifySessionInfoChanged();


### PR DESCRIPTION
**Сделано**
Добавлено свойство для состояния сессии - бюллетень голосования, которая представляет набор доступных голосов. Набор доступных голосов можно выбрать при создании сессии или при ее изменении.
Если какие то голоса стали недоступными, то уже зафиксированные голоса сбросятся.

Bulletin - класс, который представляет бюллетень.
BulletinItem - класс представляет элемент бюллетени, который может быть доступен или нет.
По умолчанию сессия создается с набором Фибоначчи, знаком вопроса и чашкой кофе.

Настройка кастомных наборов в этом ПР не поддерживается, только изменение набора по умолчанию.
Возможность изменять набор карт доступных для голосования задается в диалоге редактирования сессии.

**Проверено**
- Проверял старую сессию, что ничего не упадет при ее активации - работает
- Для старой сессии пробовал изменять набор - работает
- Создавал новую сессию, предварительно изменяя набор карт - работает
- Изменял существующую сессию, в том числе снимал все галки с карт - работает.