### PR TITLE
Для участников сессии добавлен бейдж со статусом "в сети/не в сети"

### DIFF
--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/ParticipantsVotesList.razor
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/ParticipantsVotesList.razor
@@ -22,7 +22,7 @@
     @foreach (var participant in this.PaticipantVotes.OrderByDescending(p => p.Id == this.ParticipantId))
     {
       <MudListItem>
-        <div class="d-flex align-center justify-space-between">
+        <div @key="@participant.Id" class="d-flex align-center justify-space-between">
           <div class="d-flex align-center">
             <div class="mr-3">
               <OnlineStatusBadge ParticipantId="participant.Id">

--- a/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/ParticipantsVotesList.razor
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Pages/Components/ParticipantsVotesList.razor
@@ -25,7 +25,11 @@
         <div class="d-flex align-center justify-space-between">
           <div class="d-flex align-center">
             <div class="mr-3">
-              <Avatar Url="@participant.AvatarUrl" />
+              <OnlineStatusBadge ParticipantId="participant.Id">
+                <BadgeContent>
+                  <Avatar Url="@participant.AvatarUrl" />
+                </BadgeContent>
+              </OnlineStatusBadge>
             </div>
             <MudText Class="my-0 mr-2 d-none d-md-block">
               @(string.IsNullOrEmpty(participant.Name) ? UIResources.NamelessParticipantName : participant.Name)

--- a/Yotalab.PlanningPoker.BlazorServerSide/Services/TrackingCircuitHandler.cs
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Services/TrackingCircuitHandler.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Server.Circuits;
+using Microsoft.AspNetCore.Identity;
+
+namespace Yotalab.PlanningPoker.BlazorServerSide.Services
+{
+  public class TrackingCircuitHandler : CircuitHandler
+  {
+    private readonly AuthenticationStateProvider authenticationStateProvider;
+    private readonly UserManager<IdentityUser> userManager;
+    private readonly UsersActivityService userActivityService;
+
+    public TrackingCircuitHandler(
+      AuthenticationStateProvider authenticationStateProvider,
+      UserManager<IdentityUser> userManager,
+      UsersActivityService userActivityService)
+    {
+      this.authenticationStateProvider = authenticationStateProvider;
+      this.userManager = userManager;
+      this.userActivityService = userActivityService;
+    }
+
+    public override async Task OnCircuitOpenedAsync(Circuit circuit, CancellationToken cancellationToken)
+    {
+      await base.OnCircuitOpenedAsync(circuit, cancellationToken);
+
+      var user = await GetCurrentUserAsync();
+      if (user == null)
+        return;
+
+      await this.userActivityService.SetOnline(Guid.Parse(user.Id), circuit.Id);
+    }
+
+    public override async Task OnCircuitClosedAsync(Circuit circuit, CancellationToken cancellationToken)
+    {
+      await base.OnCircuitClosedAsync(circuit, cancellationToken);
+
+      var user = await GetCurrentUserAsync();
+      if (user == null)
+        return;
+
+      await this.userActivityService.SetOffline(Guid.Parse(user.Id), circuit.Id);
+    }
+
+    private async Task<IdentityUser> GetCurrentUserAsync()
+    {
+      var authState = await this.authenticationStateProvider?.GetAuthenticationStateAsync();
+      if (authState == null)
+        return null;
+
+      return await userManager.GetUserAsync(authState.User);
+    }
+  }
+}

--- a/Yotalab.PlanningPoker.BlazorServerSide/Services/UsersActivityService.cs
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Services/UsersActivityService.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Orleans;
+using Orleans.Streams;
+using Yotalab.PlanningPoker.Grains.Interfaces;
+using Yotalab.PlanningPoker.Grains.Interfaces.Models.Notifications;
+
+namespace Yotalab.PlanningPoker.BlazorServerSide.Services
+{
+  public class UsersActivityService
+  {
+    private readonly IClusterClient client;
+    private readonly ILogger<UsersActivityService> logger;
+
+    public UsersActivityService(IClusterClient client, ILogger<UsersActivityService> logger)
+    {
+      this.client = client;
+      this.logger = logger;
+    }
+
+    public Task SetOnline(Guid userId, string clientId)
+    {
+      var userOnlineStatus = this.client.GetGrain<IUserOnlineStatusGrain>(userId);
+      return userOnlineStatus.Online(clientId);
+    }
+
+    public Task SetOffline(Guid userId, string clientId)
+    {
+      var userOnlineStatus = this.client.GetGrain<IUserOnlineStatusGrain>(userId);
+      return userOnlineStatus.Offline(clientId);
+    }
+
+    public Task<bool> GetOnlineStatus(Guid userId)
+    {
+      var userOnlineStatus = this.client.GetGrain<IUserOnlineStatusGrain>(userId);
+      return userOnlineStatus.IsOnline();
+    }
+
+    public Task<StreamSubscriptionHandle<UserOnlineStatusChanged>> SubscribeAsync(Guid userId, Func<UserOnlineStatusChanged, Task> action) =>
+        this.client.GetStreamProvider("SMS")
+            .GetStream<UserOnlineStatusChanged>(userId, typeof(UserOnlineStatusChanged).FullName)
+            .SubscribeAsync(new NotificationsObserver<UserOnlineStatusChanged>(this.logger, action));
+  }
+}

--- a/Yotalab.PlanningPoker.BlazorServerSide/Shared/OnlineStatusBadge.razor
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Shared/OnlineStatusBadge.razor
@@ -1,0 +1,20 @@
+﻿@{
+  var className = $"mud-badge-{this.BadgeSize.ToString().ToLower()}";
+}
+@if (Guid.Empty.Equals(this.ParticipantId))
+{
+  @BadgeContent
+}
+else
+{
+  <div class="online-status">
+    <MudBadge Class="@className"
+            Origin="Origin.BottomRight"
+            Color="this.isOnline ? Color.Success : Color.Default"
+            Overlap="true"
+            Bordered="true"
+            Dot="this.BadgeSize == Size.Small">
+      @BadgeContent
+    </MudBadge>
+  </div>
+}

--- a/Yotalab.PlanningPoker.BlazorServerSide/Shared/OnlineStatusBadge.razor.cs
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Shared/OnlineStatusBadge.razor.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Orleans.Streams;
+using Yotalab.PlanningPoker.BlazorServerSide.Services;
+using Yotalab.PlanningPoker.Grains.Interfaces.Models.Notifications;
+
+namespace Yotalab.PlanningPoker.BlazorServerSide.Shared
+{
+  public partial class OnlineStatusBadge : IAsyncDisposable
+  {
+    private StreamSubscriptionHandle<UserOnlineStatusChanged> userOnlineTrackingSubscription;
+
+    private bool isOnline = false;
+
+    [Inject]
+    private UsersActivityService ActivityService { get; set; }
+
+    [Parameter]
+    public Size BadgeSize { get; set; } = Size.Medium;
+
+    [Parameter]
+    public RenderFragment BadgeContent { get; set; }
+
+    [Parameter]
+    public Guid ParticipantId { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+      if (!Guid.Empty.Equals(this.ParticipantId))
+      {
+        // Обработка изменения состояния "в сети" для пользователя.
+        this.userOnlineTrackingSubscription = await this.ActivityService.SubscribeAsync(this.ParticipantId,
+          notification => this.InvokeAsync(() => this.HandleNotification(notification)));
+
+        this.isOnline = await this.ActivityService.GetOnlineStatus(this.ParticipantId);
+        this.StateHasChanged();
+      }
+    }
+
+    private Task HandleNotification(UserOnlineStatusChanged notification)
+    {
+      if (this.ParticipantId == notification.UserId)
+      {
+        this.isOnline = notification.IsOnline;
+        this.StateHasChanged();
+      }
+
+      return Task.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+      try
+      {
+        await this.userOnlineTrackingSubscription?.UnsubscribeAsync();
+      }
+      catch
+      {
+        // Игнорируем.
+      }
+    }
+  }
+}

--- a/Yotalab.PlanningPoker.BlazorServerSide/Shared/OnlineStatusBadge.razor.css
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Shared/OnlineStatusBadge.razor.css
@@ -1,0 +1,9 @@
+﻿.online-status ::deep .mud-badge-medium .mud-badge {
+  height: 14px;
+  min-width: 14px;
+}
+
+.online-status ::deep .mud-badge-small .mud-badge {
+  left: 21px;
+  top: 17px;
+}

--- a/Yotalab.PlanningPoker.BlazorServerSide/Startup.cs
+++ b/Yotalab.PlanningPoker.BlazorServerSide/Startup.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -6,6 +7,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.FeatureManagement;
 using MudBlazor.Services;
+using Orleans;
 using Yotalab.PlanningPoker.BlazorServerSide.Filters;
 using Yotalab.PlanningPoker.BlazorServerSide.Services;
 using Yotalab.PlanningPoker.BlazorServerSide.Services.FilesStoraging;
@@ -32,6 +34,8 @@ namespace Yotalab.PlanningPoker.BlazorServerSide
       services.AddServerSideBlazor();
       services.AddLocalization();
 
+      services.AddScoped<CircuitHandler, TrackingCircuitHandler>();
+
       if (this.Environment.IsDevelopment())
       {
         services.AddDatabaseDeveloperPageExceptionFilter();
@@ -55,6 +59,7 @@ namespace Yotalab.PlanningPoker.BlazorServerSide
 
       services.AddSingleton<SessionService>();
       services.AddSingleton<ParticipantsService>();
+      services.AddSingleton<UsersActivityService>();
       services.AddScoped<JSInteropFunctions>();
       services.AddMudServices();
       services.AddHttpClient();

--- a/Yotalab.PlanningPoker.Grains.Interfaces/IUserOnlineStatusGrain.cs
+++ b/Yotalab.PlanningPoker.Grains.Interfaces/IUserOnlineStatusGrain.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using Orleans;
+
+namespace Yotalab.PlanningPoker.Grains.Interfaces
+{
+  public interface IUserOnlineStatusGrain : IGrainWithGuidKey
+  {
+    Task Online(string clientId);
+
+    Task Offline(string clientId);
+
+    Task<bool> IsOnline();
+  }
+}

--- a/Yotalab.PlanningPoker.Grains.Interfaces/Models/Notifications/UserOnlineStatusChanged.cs
+++ b/Yotalab.PlanningPoker.Grains.Interfaces/Models/Notifications/UserOnlineStatusChanged.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Orleans.Concurrency;
+
+namespace Yotalab.PlanningPoker.Grains.Interfaces.Models.Notifications
+{
+  [Immutable]
+  public class UserOnlineStatusChanged
+  {
+    public UserOnlineStatusChanged(Guid userId, bool isOnline)
+    {
+      this.UserId = userId;
+      this.IsOnline = isOnline;
+    }
+
+    public Guid UserId { get; }
+
+    public bool IsOnline { get; }
+  }
+}

--- a/Yotalab.PlanningPoker.Grains.Interfaces/Yotalab.PlanningPoker.Grains.Interfaces.csproj
+++ b/Yotalab.PlanningPoker.Grains.Interfaces/Yotalab.PlanningPoker.Grains.Interfaces.csproj
@@ -14,4 +14,8 @@
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Orleans_CodeGenInputs Remove="IUserOnlineStatusGrain.cs" />
+  </ItemGroup>
+
 </Project>

--- a/Yotalab.PlanningPoker.Grains/UserOnlineStatusGrain.cs
+++ b/Yotalab.PlanningPoker.Grains/UserOnlineStatusGrain.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans;
+using Yotalab.PlanningPoker.Grains.Interfaces;
+using Yotalab.PlanningPoker.Grains.Interfaces.Models.Notifications;
+
+namespace Yotalab.PlanningPoker.Grains
+{
+  public class UserOnlineStatusGrain : Grain, IUserOnlineStatusGrain
+  {
+    private IDisposable offlineNotificationTimer;
+
+    private HashSet<string> clients = new HashSet<string>();
+
+    private bool HasActiveClients => this.clients.Count > 0;
+
+    public Task<bool> IsOnline()
+    {
+      return Task.FromResult(this.HasActiveClients);
+    }
+
+    public Task Offline(string clientId)
+    {
+      var isRemoved = this.clients.Remove(clientId);
+      if (this.clients.Count == 0 && isRemoved)
+      {
+        this.offlineNotificationTimer?.Dispose();
+
+        // Делаем небольшую задержку, чтобы исключить ситуации быстрого обновления статуса.
+        // Например, если пользователь обновил страницу, то без задержки статус успеет моргнуть.
+        this.offlineNotificationTimer = this.RegisterTimer(
+          this.OnNotifyOfflineTimer, null, TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(500));
+      }
+
+      return Task.CompletedTask;
+    }
+
+    public Task Online(string clientId)
+    {
+      var isAdded = this.clients.Add(clientId);
+      if (this.clients.Count == 1 && isAdded)
+      {
+        // Если пользователь успел появиться в сети, то не нужно уведомлять об выходе из сети.
+        this.offlineNotificationTimer?.Dispose();
+
+        this.NotifyOnlineStatusChanged();
+      }
+
+      return Task.CompletedTask;
+    }
+
+    private Task OnNotifyOfflineTimer(object state)
+    {
+      this.NotifyOnlineStatusChanged();
+      return Task.CompletedTask;
+    }
+
+    private void NotifyOnlineStatusChanged()
+    {
+      var userId = this.GetPrimaryKey();
+      this.GetStreamProvider("SMS").GetStream<UserOnlineStatusChanged>(userId, typeof(UserOnlineStatusChanged).FullName)
+        .OnNextAsync(new UserOnlineStatusChanged(userId, this.HasActiveClients))
+        .Ignore();
+    }
+  }
+}

--- a/Yotalab.PlanningPoker.Grains/Yotalab.PlanningPoker.Grains.csproj
+++ b/Yotalab.PlanningPoker.Grains/Yotalab.PlanningPoker.Grains.csproj
@@ -17,4 +17,8 @@
     <ProjectReference Include="..\Yotalab.PlanningPoker.Grains.Interfaces\Yotalab.PlanningPoker.Grains.Interfaces.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Orleans_CodeGenInputs Remove="UserOnlineStatusGrain.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
**Что сделано**
- Добавлен грейн IUserOnlineStatusGrain, который хранит информацию о пользователе если он online.
- Для пользователя может быть несколько клиентов (несколько вкладок браузера, несколько окон и т.п.). Пользователь считается в сети, пока есть хотя бы один подключенный клиент.
- Добавлен бейдж в список участников сессии со статусом в сети/не в сети.
- Добавлен обработчик circuit, чтобы отслеживать подключение отключение пользователей.

**Как проверял**
- С разных браузеров подключался к сессии, смотрел что бейдж показывает статус корректно
- Проверял, что и в предыдущем пункте, но только со второго браузера нажимал "Обновить" для страницы, смотрел, что статус не мигает.
- Подключался под одним пользователем на разных вкладках, разных браузерах, смотрел что при выходе с разных вкладок/браузеров состояние не переходит в "не в сети", а переходит только когда все вкладки пользователя закрыты.